### PR TITLE
Enhancement to support Docker Compose 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,91 @@
+FROM elixir:alpine
+
+ARG app_name=plausible
+ARG phoenix_subdir=.
+ARG build_env=prod
+ARG AVIEN_DATABASE_URL=""
+
+# Set up build environment.
+ENV MIX_ENV=${build_env} \
+  REPLACE_OS_VARS=true \
+  TERM=xterm
+ENV AVIEN_DATABASE_URL=${AVIEN_DATABASE_URL}
+RUN set -xe
+RUN echo "MIX_ENV=$MIX_ENV"
+RUN echo "AVIEN_DATABASE_URL=$AVIEN_DATABASE_URL"
+
+# Set the build directory.
+RUN mkdir /opt/app
+WORKDIR /opt/app
+
+# Install build tools needed in addition to Elixir:
+# NodeJS is used for Webpack builds of Phoenix assets.
+# Hex and Rebar are needed to get and build dependencies.
+
+# This step installs all the build tools we'll need
+RUN apk update && \
+  apk upgrade --no-cache && \
+  apk add --no-cache \
+  postgresql-client \
+  nodejs \
+  npm \
+  git \
+  build-base && \
+  mix local.rebar --force && \
+  mix local.hex --force
+
+# Copy the application files into /opt/app.
+COPY . .
+
+# Build the application.
+RUN mix do deps.get --only $MIX_ENV, deps.compile
+
+# Build assets by running a Webpack build and Phoenix digest.
+# If you are using a different mechanism for asset builds, you may need to
+# alter these commands.
+RUN cd ${phoenix_subdir}/assets \
+  && npm install \
+  && ./node_modules/webpack/bin/webpack.js --mode production \
+  && cd .. \
+  && mix phx.digest
+
+# Create the release, and move the artifacts to well-known paths so the
+# runtime image doesn't need to know the app name. Specifically, the binary
+# is renamed to "start_server", and the entire release is moved into
+# /opt/release.
+RUN mix release \
+  && mv _build/${build_env}/rel/${app_name} /opt/release \
+  && mv /opt/release/bin/${app_name} /opt/release/bin/start_server
+
+# # Step 2: Execute the application
+# FROM alpine:latest
+
+# RUN apk update \
+#     && apk --no-cache --update add bash ca-certificates openssl-dev
+
+ENV PORT=4000 \
+  REPLACE_OS_VARS=true
+EXPOSE ${PORT}
+EXPOSE 8000
+
+# # Set the install directory. The app will run from here.
+# WORKDIR /opt/app
+
+# # Obtain the built application release from the build stage.
+# COPY --from=0 /opt/release .
+# #COPY --from=releaser app/bin/ ./bin
+
+
+# # Copy the Docker entrypoint.sh to the release docker image
+# COPY --from=0 /opt/app/entrypoint.sh .
+
+# # Start the server.
+
+# # # CMD exec /opt/app/bin/start_server start
+
+RUN chmod +x /opt/app/entrypoint.sh
+
+# CMD /opt/app/entrypoint.sh
+# CMD tail -f /dev/null
+
+ENTRYPOINT /opt/app/entrypoint.sh

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -37,9 +37,9 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :plausible, Plausible.Repo,
   username: "postgres",
-  password: "postgres",
-  database: "plausible_dev",
-  hostname: "localhost",
+  password: System.get_env("PGPASSWORD") || "mysecretpassword",
+  database: "postgres",
+  hostname: System.get_env("POSTGRES_HOST") || "localhost",
   pool_size: 10
 
 config :plausible, Plausible.Mailer,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.5'
+
+services:
+  plausible:
+    container_name: plausible
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        build_env: prod
+    ports:
+      - 4000:4000
+      - 8000:8000
+    environment:
+      # # Hostname of our Postgres container
+      POSTGRES_HOST: postgres
+      # Convenience variable for when running psql
+      PGPASSWORD: mysecretpassword
+      # Appliction environment variables
+      SECRET_KEY_BASE: /NJrhNtbyCVAsTyvtk1ZYCwfm981Vpo/0XrVwjJvemDaKC/vsvBRevLwsc6u8RCg
+      APP_ENV: prod
+      DATABASE_URL: postgres:mysecretpassword@postgres:5432/plausible_dev
+      AVIEN_DATABASE_URL: postgres:mysecretpassword@postgres:5432/plausible_dev
+      GOOGLE_CLIENT_ID: dummy-env-variable
+      GOOGLE_CLIENT_SECRET: dummy-env-variable
+      SLACK_WEBHOOK: dummy-env-variable
+      POSTMARK_API_KEY: dummy-env-variable
+      TWITTER_CONSUMER_KEY: dummy-env-variable
+      TWITTER_CONSUMER_SECRET: dummy-env-variable
+      TWITTER_ACCESS_TOKEN: dummy-env-variable
+      TWITTER_ACCESS_TOKEN_SECRET: dummy-env-variable
+      POOL_SIZE: 10
+      PORT: 4000
+    depends_on:
+      - postgres
+    links:
+      - postgres
+  postgres:
+    container_name: postgres_container
+    image: postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mysecretpassword}
+      POSTGRES_DB: ${POSTGRES_DB:-plausible_dev}
+      PGDATA: /data/postgres
+    volumes:
+       - pgdata:/data/postgres
+    ports:
+      - "5432:5432"
+    restart: unless-stopped
+volumes:
+ pgdata: {}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,29 @@
+# #!/bin/sh
+set -e
+set -x
+
+
+# Ensure the app's dependencies are installed
+mix deps.get
+
+# Install Javascript libraries
+echo "\nInstalling Javascript dependencies..."
+cd assets && npm install
+cd ..
+
+# Wait for Postgres to become available.
+until psql -h postgres -U "postgres" -c '\q' 2>/dev/null; do
+   >&2 echo "Postgres is unavailable - sleeping"
+   sleep 1
+done
+
+echo "\nPostgres is available: continuing with database setup..."
+
+# # Potentially Set up the database
+MIX_ENV=dev mix ecto.create
+MIX_ENV=dev mix ecto.migrate
+
+echo "\n Launching Phoenix web server..."
+
+# Start the phoenix web server
+MIX_ENV=dev mix phx.server


### PR DESCRIPTION
I have written a `Dockerfile` and a `docker-compose.yml` to allow running Plausible within Docker, the docker compose will create a `postgres`-database, and also will build the `Plausible` docker image you can try it out using;

```
docker-compose build
docker-compose up
```

After the latter command succeeds you should have access to the development build of Plausible at url http://localhost:8000. You can use the docker logs to dig up the verification url from the mail ;)

Of course, this is not the right way to run things in Production but I don't have enough experience with Elixer to make this work. I tried to make a release but that didn't work as it appears use the environment variables at build time when running the release. If anyone know how to do this that would be great :)