### PR TITLE
Exclude loopback addresses from analytics

### DIFF
--- a/assets/js/p.js
+++ b/assets/js/p.js
@@ -57,7 +57,7 @@
     }
 
     function trigger(eventName, options) {
-      if (/localhost$/.test(window.location.hostname)) return ignore('website is running locally');
+      if (/^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/.test(window.location.hostname)) return ignore('website is running locally');
       if (window.location.protocol === 'file:') return ignore('website is running locally');
       if (window.document.visibilityState === 'prerender') return ignore('document is prerendering');
 

--- a/assets/js/plausible.js
+++ b/assets/js/plausible.js
@@ -62,7 +62,7 @@
     }
 
     function trigger(eventName, options) {
-      if (/localhost$/.test(window.location.hostname)) return ignore('website is running locally');
+      if (/^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/.test(window.location.hostname)) return ignore('website is running locally');
       if (window.location.protocol === 'file:') return ignore('website is running locally');
       if (window.document.visibilityState === 'prerender') return ignore('document is prerendering');
 


### PR DESCRIPTION
I happened to notice that Plausible was still sending analytics events while I was running my website locally. While `localhost` is already excluded, other loopback addresses like `127.0.0.1` (which is the address I was using, in this case) are not.

This PR prevents analytics from being collected for loopback addresses in addition to localhost.

The regex used to match loopback addresses was taken from [this Stack Overflow](https://stackoverflow.com/a/8426365) post.

<details>
This RegEx matches
The string "localhost"

localhost
LOCALHOST
These permutations of the IPv4 loopback address

127.0.0.1
127.0.0.001
127.0.00.1
127.00.0.1
127.000.000.001
127.0000.0000.1
127.0.01
127.1
127.001
127.0.0.254
127.63.31.15
127.255.255.254
These permutations of the IPv6 loopback address

0:0:0:0:0:0:0:1
0000:0000:0000:0000:0000:0000:0000:0001
::1
0::1
0:0:0::1
0000::0001
0000:0:0000::0001
0000:0:0000::1
0::0:1
This RegEx does not match
A valid server name

servername
subdomain.domain.tld
These valid IPv4 addresses

192.168.0.1
10.1.1.123
These valid IPv6 addresses

0001::1
dead:beef::1
::dead:beef:1
</details>

Cheers!